### PR TITLE
Neelfoo

### DIFF
--- a/app/src/main/java/com/CMPUT301W20T24/OnMyWay/DriverMapActivity.java
+++ b/app/src/main/java/com/CMPUT301W20T24/OnMyWay/DriverMapActivity.java
@@ -458,7 +458,7 @@ public class DriverMapActivity extends AppCompatActivity implements OnMapReadyCa
                 calculateDirectionsDestination(marker);
                 showDialogue();
 
-                return false;
+                return true;
             }
         });
     }


### PR DESCRIPTION
- The DriverMap won't re-center when a marker is clicked (makes it somewhat easier to see the polylines)
- When a marker is clicked, that marker will remain, a destination marker will show, and the polylines will show. Everything else will be cleared.
- When the dialogue is dismissed, the entire map will clear, and loadMarkers() will be called. This has the 'benefit' of refreshing the currently available rides, instead of just loading old markers.

